### PR TITLE
Flexible schedules: weekly habits on several weekdays, every-N-days intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 - 🎠 **Carousel dashboard** — log your habits from any note with a `habits` code block, with satisfying completion animations
 - ✅ **Three habit types** — done/not-done, counted (8 cups of water), and timed (30 minutes of exercise, with +1/+5/+10 quick buttons)
-- 🗓️ **Daily, weekly, or monthly** — pick a frequency per habit; weekly and monthly habits appear only on their due day, and streaks count consecutive weeks or months
+- 🗓️ **Flexible schedules** — daily, weekly on one or several weekdays (Mon/Wed/Fri), monthly, or every N days (alternate-day medication); non-daily habits appear only on their due day, and streaks count due days, not calendar days
 - 🔥 **Streaks and statistics** — current and best streaks, completion rates, perfect days, weekly and monthly goals, per-habit heatmaps over the week, month, or any custom date range
 - 📊 **Charts on every habit page** — 30-day activity and 12-week trend charts rendered in your theme's colours
 - 📄 **Printable PDF reports** — pick your metrics, date range, and layout with a live A4 preview
@@ -70,17 +70,18 @@ pauses:
 
 No databases, no external services — delete the plugin and your history is still right there in your notes.
 
-## 🗓️ Daily, weekly, and monthly habits
+## 🗓️ Daily, weekly, monthly, and every-N-days habits
 
 Every habit has a **frequency**, chosen when you create or edit it:
 
 - **Daily** — due every day (the default).
-- **Weekly** — due once a week on the weekday you pick. The card only appears on that day.
+- **Weekly** — due on the weekdays you pick, one or several (a gym habit on Mon/Wed/Fri is one habit, one streak). The card only appears on those days. A single day is stored as `weekday: 5` in frontmatter; several days as `weekdays: [1, 3, 5]` (JavaScript `getDay` numbers, `0` = Sunday).
 - **Monthly** — due once a month on the day you pick. Months shorter than the chosen day fall due on their **last day**, so the 31st always lands on the final day of the month (28th or 29th in February, 30th in April, and so on) — you never miss a month.
+- **Every N days** — due every N days counted from the habit's start date, so an alternate-day schedule (N = 2) stays put even when you miss a day — just like a prescription. Stored as `frequency: interval` with `intervalDays: 2` in frontmatter; hand-written notes without a `startDate` anchor on their earliest record instead.
 
-Weekly and monthly cards surface only on their due date in both the dashboard and the sidebar panel, so your list stays focused on what's actually due. Their **streaks and stats count periods, not days**: a weekly habit's streak is the number of consecutive weeks you completed it, and a monthly habit's is consecutive months. Days a habit isn't due don't count against its completion rate. To log a due date you missed, use the dashboard's date arrows to step back to it.
+Non-daily cards surface only on their due dates in both the dashboard and the sidebar panel, so your list stays focused on what's actually due. Their **streaks and stats count due days, not calendar days**: a Sunday-only habit's streak is the number of consecutive weeks you completed it, a Mon/Wed/Fri habit's is consecutive due days, and a monthly habit's is consecutive months. Days a habit isn't due don't count against its completion rate. To log a due date you missed, use the dashboard's date arrows to step back to it.
 
-The charts on a weekly or monthly habit's page adapt too: instead of a 30-day grid, the activity chart plots each recent **due date** (labelled with the date it lands on), and a rolling completion-rate line shows the trend across periods. The summary tiles relabel accordingly — "Weeks completed" or "Months completed" rather than "Days completed".
+The charts on a non-daily habit's page adapt too: instead of a 30-day grid, the activity chart plots each recent **due date** (labelled with the date it lands on), and a rolling completion-rate line shows the trend across periods. The summary tiles relabel accordingly — "Weeks completed" or "Months completed" rather than "Days completed".
 
 ## 🎠 The dashboard
 

--- a/src/ai-summary.ts
+++ b/src/ai-summary.ts
@@ -117,7 +117,9 @@ export function buildStatsDigest(
 				);
 			}
 		}
-		if (habit.frequency !== "daily") {
+		if (habit.frequency === "interval") {
+			parts.push(`due every ${habit.intervalDays} days`);
+		} else if (habit.frequency !== "daily") {
 			parts.push(`due ${habit.frequency}`);
 		}
 		parts.push(`${Math.round(s.rate * 100)}% rate`);

--- a/src/habit-store.ts
+++ b/src/habit-store.ts
@@ -16,6 +16,7 @@ const HABIT_FREQUENCIES: readonly HabitFrequency[] = [
 	"daily",
 	"weekly",
 	"monthly",
+	"interval",
 ];
 
 function isHabitType(value: unknown): value is HabitType {
@@ -132,8 +133,13 @@ export class HabitStore {
 			frequency: isHabitFrequency(fm.frequency)
 				? fm.frequency
 				: "daily",
-			weekday: this.clampInt(this.readNumber(fm.weekday, 1), 0, 6),
+			weekdays: this.readWeekdays(fm.weekdays, fm.weekday),
 			monthDay: this.clampInt(this.readNumber(fm.monthDay, 1), 1, 31),
+			intervalDays: this.clampInt(
+				this.readNumber(fm.intervalDays, 2),
+				2,
+				365,
+			),
 			target: this.readNumber(fm.target, 1),
 			unit: typeof fm.unit === "string" ? fm.unit : "",
 			weeklyTarget: this.readNumber(fm.weeklyTarget, 0),
@@ -170,6 +176,35 @@ export class HabitStore {
 	/** Round to a whole number and constrain it to an inclusive range. */
 	private clampInt(value: number, min: number, max: number): number {
 		return Math.min(max, Math.max(min, Math.round(value)));
+	}
+
+	/**
+	 * Parse a weekly habit's due days: the `weekdays` list when present,
+	 * otherwise the original scalar `weekday`. Values are clamped to `0`–`6`,
+	 * deduplicated and sorted; with nothing usable the result falls back to
+	 * `[1]` (Monday), matching the old scalar default.
+	 */
+	private readWeekdays(list: unknown, single: unknown): number[] {
+		const raw = Array.isArray(list) ? list : [single];
+		const days = new Set<number>();
+		for (const value of raw) {
+			const parsed = this.readNumber(value, NaN);
+			if (Number.isFinite(parsed)) {
+				days.add(this.clampInt(parsed, 0, 6));
+			}
+		}
+		if (days.size === 0) {
+			days.add(1);
+		}
+		return [...days].sort((a, b) => a - b);
+	}
+
+	/** Clamp, deduplicate and sort a weekday list, defaulting to Monday. */
+	private normalizeWeekdays(values: number[]): number[] {
+		const days = [
+			...new Set(values.map((value) => this.clampInt(value, 0, 6))),
+		].sort((a, b) => a - b);
+		return days.length > 0 ? days : [1];
 	}
 
 	private readRecords(raw: unknown): Record<string, number> {
@@ -258,25 +293,35 @@ export class HabitStore {
 
 	/**
 	 * Write the frequency fields to frontmatter, keeping it tidy: daily habits
-	 * store nothing (it is the default), and only the field relevant to the
-	 * chosen frequency is kept so stale keys never linger after a change.
+	 * store nothing (it is the default), and only the fields relevant to the
+	 * chosen frequency are kept so stale keys never linger after a change.
+	 * A weekly habit due on a single day keeps the original scalar `weekday`
+	 * form, so notes from before multi-day support are rewritten unchanged.
 	 */
 	private writeFrequency(
 		fm: Record<string, unknown>,
 		options: NewHabitOptions,
 	): void {
+		delete fm.weekday;
+		delete fm.weekdays;
+		delete fm.monthDay;
+		delete fm.intervalDays;
 		if (options.frequency === "weekly") {
 			fm.frequency = "weekly";
-			fm.weekday = this.clampInt(options.weekday, 0, 6);
-			delete fm.monthDay;
+			const days = this.normalizeWeekdays(options.weekdays);
+			if (days.length === 1) {
+				fm.weekday = days[0];
+			} else {
+				fm.weekdays = days;
+			}
 		} else if (options.frequency === "monthly") {
 			fm.frequency = "monthly";
 			fm.monthDay = this.clampInt(options.monthDay, 1, 31);
-			delete fm.weekday;
+		} else if (options.frequency === "interval") {
+			fm.frequency = "interval";
+			fm.intervalDays = this.clampInt(options.intervalDays, 2, 365);
 		} else {
 			delete fm.frequency;
-			delete fm.weekday;
-			delete fm.monthDay;
 		}
 	}
 

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -333,21 +333,30 @@ export const de: Record<string, string> = {
 	// Frequencies and per-note metrics
 	Frequency: "Häufigkeit",
 	Daily: "Täglich",
-	"Day of week": "Wochentag",
+	"Days of week": "Wochentage",
+	"Every N days": "Alle N Tage",
+	"Repeat every": "Wiederholen alle",
 	"Day of month": "Tag des Monats",
 	"How often this habit is due. Weekly and monthly habits only appear on their due date.":
 		"Wie oft diese Gewohnheit fällig ist. Wöchentliche und monatliche Gewohnheiten erscheinen nur an ihrem Fälligkeitstag.",
-	"The weekday this habit is due on.":
-		"Der Wochentag, an dem diese Gewohnheit fällig ist.",
+	"The weekdays this habit is due on. Pick as many as you need.":
+		"Die Wochentage, an denen diese Gewohnheit fällig ist. Wähle so viele wie nötig.",
+	"Number of days between due dates, counted from the habit's start date. Use 2 for an alternate-day schedule.":
+		"Anzahl der Tage zwischen den Fälligkeiten, gezählt ab dem Startdatum der Gewohnheit. 2 ergibt einen Rhythmus von jedem zweiten Tag.",
 	"The day of the month this habit is due. In shorter months it falls due on the last day, so 31 always lands on the final day of the month.":
 		"Der Tag des Monats, an dem diese Gewohnheit fällig ist. In kürzeren Monaten fällt sie auf den letzten Tag, sodass 31 immer auf den letzten Tag des Monats fällt.",
 	"Every {day}": "Jeden {day}",
 	"Monthly · day {day}": "Monatlich · Tag {day}",
+	"Every other day": "Jeden zweiten Tag",
+	"Every {n} days": "Alle {n} Tage",
 	"No habits are due on this day.":
 		"An diesem Tag sind keine Gewohnheiten fällig.",
 	"Nothing due today.": "Heute ist nichts fällig.",
 	"Weekly activity": "Wöchentliche Aktivität",
 	"Monthly activity": "Monatliche Aktivität",
+	"Activity on due days": "Aktivität an Fälligkeitstagen",
+	"Completion rate over {n} due days":
+		"Erfolgsquote über {n} Fälligkeitstage",
 	"Weeks completed": "Abgeschlossene Wochen",
 	"Months completed": "Abgeschlossene Monate",
 	"Recent rate": "Aktuelle Quote",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -332,20 +332,29 @@ export const es: Record<string, string> = {
 	// Frequencies and per-note metrics
 	Frequency: "Frecuencia",
 	Daily: "Diario",
-	"Day of week": "Día de la semana",
+	"Days of week": "Días de la semana",
+	"Every N days": "Cada N días",
+	"Repeat every": "Repetir cada",
 	"Day of month": "Día del mes",
 	"How often this habit is due. Weekly and monthly habits only appear on their due date.":
 		"Con qué frecuencia vence este hábito. Los hábitos semanales y mensuales solo aparecen en su día de vencimiento.",
-	"The weekday this habit is due on.":
-		"El día de la semana en que vence este hábito.",
+	"The weekdays this habit is due on. Pick as many as you need.":
+		"Los días de la semana en que vence este hábito. Elige tantos como necesites.",
+	"Number of days between due dates, counted from the habit's start date. Use 2 for an alternate-day schedule.":
+		"Número de días entre vencimientos, contado desde la fecha de inicio del hábito. Usa 2 para un esquema de días alternos.",
 	"The day of the month this habit is due. In shorter months it falls due on the last day, so 31 always lands on the final day of the month.":
 		"El día del mes en que vence este hábito. En meses más cortos vence el último día, así que 31 siempre cae en el último día del mes.",
 	"Every {day}": "Cada {day}",
 	"Monthly · day {day}": "Mensual · día {day}",
+	"Every other day": "Cada dos días",
+	"Every {n} days": "Cada {n} días",
 	"No habits are due on this day.": "Ningún hábito vence este día.",
 	"Nothing due today.": "Nada vence hoy.",
 	"Weekly activity": "Actividad semanal",
 	"Monthly activity": "Actividad mensual",
+	"Activity on due days": "Actividad en días de vencimiento",
+	"Completion rate over {n} due days":
+		"Tasa de cumplimiento en {n} días de vencimiento",
 	"Weeks completed": "Semanas completadas",
 	"Months completed": "Meses completados",
 	"Recent rate": "Tasa reciente",

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -332,21 +332,30 @@ export const fr: Record<string, string> = {
 	// Frequencies and per-note metrics
 	Frequency: "Fréquence",
 	Daily: "Quotidien",
-	"Day of week": "Jour de la semaine",
+	"Days of week": "Jours de la semaine",
+	"Every N days": "Tous les N jours",
+	"Repeat every": "Répéter tous les",
 	"Day of month": "Jour du mois",
 	"How often this habit is due. Weekly and monthly habits only appear on their due date.":
 		"La fréquence à laquelle cette habitude est due. Les habitudes hebdomadaires et mensuelles n'apparaissent qu'à leur date d'échéance.",
-	"The weekday this habit is due on.":
-		"Le jour de la semaine où cette habitude est due.",
+	"The weekdays this habit is due on. Pick as many as you need.":
+		"Les jours de la semaine où cette habitude est due. Choisissez-en autant que nécessaire.",
+	"Number of days between due dates, counted from the habit's start date. Use 2 for an alternate-day schedule.":
+		"Nombre de jours entre les échéances, compté à partir de la date de début de l'habitude. Utilisez 2 pour un rythme d'un jour sur deux.",
 	"The day of the month this habit is due. In shorter months it falls due on the last day, so 31 always lands on the final day of the month.":
 		"Le jour du mois où cette habitude est due. Les mois plus courts la placent le dernier jour, donc 31 tombe toujours en fin de mois.",
 	"Every {day}": "Chaque {day}",
 	"Monthly · day {day}": "Mensuel · jour {day}",
+	"Every other day": "Un jour sur deux",
+	"Every {n} days": "Tous les {n} jours",
 	"No habits are due on this day.":
 		"Aucune habitude n'est due ce jour-là.",
 	"Nothing due today.": "Rien à faire aujourd'hui.",
 	"Weekly activity": "Activité hebdomadaire",
 	"Monthly activity": "Activité mensuelle",
+	"Activity on due days": "Activité aux jours d'échéance",
+	"Completion rate over {n} due days":
+		"Taux de réussite sur {n} jours d'échéance",
 	"Weeks completed": "Semaines accomplies",
 	"Months completed": "Mois accomplis",
 	"Recent rate": "Taux récent",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -330,21 +330,29 @@ export const ja: Record<string, string> = {
 	// Frequencies and per-note metrics
 	Frequency: "頻度",
 	Daily: "毎日",
-	"Day of week": "曜日",
+	"Days of week": "曜日",
+	"Every N days": "N日ごと",
+	"Repeat every": "繰り返し間隔",
 	"Day of month": "日にち",
 	"How often this habit is due. Weekly and monthly habits only appear on their due date.":
 		"この習慣の頻度。週間・月間の習慣は期日にのみ表示されます。",
-	"The weekday this habit is due on.":
-		"この習慣の期日となる曜日。",
+	"The weekdays this habit is due on. Pick as many as you need.":
+		"この習慣の期日となる曜日。複数選択できます。",
+	"Number of days between due dates, counted from the habit's start date. Use 2 for an alternate-day schedule.":
+		"期日と期日の間の日数。習慣の開始日から数えます。2にすると1日おきになります。",
 	"The day of the month this habit is due. In shorter months it falls due on the last day, so 31 always lands on the final day of the month.":
 		"この習慣の期日となる日。短い月では月末が期日になるため、31 は常にその月の最終日になります。",
 	"Every {day}": "毎週 {day}",
 	"Monthly · day {day}": "毎月 · {day} 日",
+	"Every other day": "1日おき",
+	"Every {n} days": "{n}日ごと",
 	"No habits are due on this day.":
 		"この日に期日の習慣はありません。",
 	"Nothing due today.": "今日は期日のものがありません。",
 	"Weekly activity": "週間アクティビティ",
 	"Monthly activity": "月間アクティビティ",
+	"Activity on due days": "期日の活動",
+	"Completion rate over {n} due days": "直近{n}回の期日の達成率",
 	"Weeks completed": "完了した週",
 	"Months completed": "完了した月",
 	"Recent rate": "最近の達成率",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -330,21 +330,29 @@ export const ko: Record<string, string> = {
 	// Frequencies and per-note metrics
 	Frequency: "주기",
 	Daily: "매일",
-	"Day of week": "요일",
+	"Days of week": "요일",
+	"Every N days": "N일마다",
+	"Repeat every": "반복 주기",
 	"Day of month": "날짜(일)",
 	"How often this habit is due. Weekly and monthly habits only appear on their due date.":
 		"이 습관의 주기입니다. 주간·월간 습관은 예정일에만 표시됩니다.",
-	"The weekday this habit is due on.":
-		"이 습관의 예정 요일입니다.",
+	"The weekdays this habit is due on. Pick as many as you need.":
+		"이 습관이 예정된 요일입니다. 여러 개를 선택할 수 있습니다.",
+	"Number of days between due dates, counted from the habit's start date. Use 2 for an alternate-day schedule.":
+		"예정일 사이의 일수로, 습관 시작일부터 계산합니다. 격일로 하려면 2를 입력하세요.",
 	"The day of the month this habit is due. In shorter months it falls due on the last day, so 31 always lands on the final day of the month.":
 		"이 습관의 예정 일자입니다. 더 짧은 달에는 마지막 날로 넘어가므로 31은 항상 그 달의 마지막 날이 됩니다.",
 	"Every {day}": "매주 {day}",
 	"Monthly · day {day}": "매월 {day}일",
+	"Every other day": "격일",
+	"Every {n} days": "{n}일마다",
 	"No habits are due on this day.":
 		"이 날에 예정된 습관이 없습니다.",
 	"Nothing due today.": "오늘은 예정된 것이 없습니다.",
 	"Weekly activity": "주간 활동",
 	"Monthly activity": "월간 활동",
+	"Activity on due days": "예정일 활동",
+	"Completion rate over {n} due days": "최근 예정일 {n}회 완료율",
 	"Weeks completed": "완료한 주",
 	"Months completed": "완료한 달",
 	"Recent rate": "최근 달성률",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -325,19 +325,28 @@ export const zh: Record<string, string> = {
 	// Frequencies and per-note metrics
 	Frequency: "频率",
 	Daily: "每天",
-	"Day of week": "星期几",
+	"Days of week": "星期几",
+	"Every N days": "每 N 天",
+	"Repeat every": "重复间隔",
 	"Day of month": "每月日期",
 	"How often this habit is due. Weekly and monthly habits only appear on their due date.":
 		"此习惯的到期频率。每周和每月习惯只在到期日显示。",
-	"The weekday this habit is due on.": "此习惯到期的星期几。",
+	"The weekdays this habit is due on. Pick as many as you need.":
+		"此习惯到期的星期几。可选择多个。",
+	"Number of days between due dates, counted from the habit's start date. Use 2 for an alternate-day schedule.":
+		"两次到期之间的天数，从习惯的开始日期算起。填 2 表示隔天一次。",
 	"The day of the month this habit is due. In shorter months it falls due on the last day, so 31 always lands on the final day of the month.":
 		"此习惯每月的到期日。在较短的月份中落在最后一天，因此 31 总是落在当月最后一天。",
 	"Every {day}": "每{day}",
 	"Monthly · day {day}": "每月 · 第 {day} 天",
+	"Every other day": "隔天一次",
+	"Every {n} days": "每 {n} 天",
 	"No habits are due on this day.": "这一天没有到期的习惯。",
 	"Nothing due today.": "今天没有到期的习惯。",
 	"Weekly activity": "每周活动",
 	"Monthly activity": "每月活动",
+	"Activity on due days": "到期日活动",
+	"Completion rate over {n} due days": "最近 {n} 个到期日的完成率",
 	"Weeks completed": "已完成周数",
 	"Months completed": "已完成月数",
 	"Recent rate": "近期完成率",

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -108,16 +108,35 @@ export function effectiveMonthDay(
 }
 
 /**
+ * The day an interval habit's every-N-days cycle counts from: its start
+ * date, or the earliest record for hand-written notes without one. `null`
+ * means no anchor exists yet (a brand-new note with no records).
+ */
+export function intervalAnchor(habit: HabitDefinition): Date | null {
+	if (habit.startDate !== "") {
+		return fromDateKey(habit.startDate);
+	}
+	const keys = Object.keys(habit.records);
+	if (keys.length > 0) {
+		return fromDateKey(keys.reduce((min, key) => (key < min ? key : min)));
+	}
+	return null;
+}
+
+/**
  * True when the habit is due on the given date.
  *
  * - `daily` habits are due every day.
- * - `weekly` habits are due on their chosen weekday.
+ * - `weekly` habits are due on their chosen weekdays.
  * - `monthly` habits are due on their chosen day of the month, clamped to the
  *   month's last day when the month is shorter.
+ * - `interval` habits are due every N days counted from their anchor (see
+ *   {@link intervalAnchor}); dates before the anchor are never due, and a
+ *   habit with no anchor yet behaves as daily until one exists.
  */
 export function isDue(habit: HabitDefinition, date: Date): boolean {
 	if (habit.frequency === "weekly") {
-		return date.getDay() === habit.weekday;
+		return habit.weekdays.includes(date.getDay());
 	}
 	if (habit.frequency === "monthly") {
 		return (
@@ -128,6 +147,18 @@ export function isDue(habit: HabitDefinition, date: Date): boolean {
 				habit.monthDay,
 			)
 		);
+	}
+	if (habit.frequency === "interval") {
+		const anchor = intervalAnchor(habit);
+		if (!anchor) {
+			return true;
+		}
+		// Both dates are local midnights; rounding absorbs the odd hour a
+		// DST transition adds or removes inside the span.
+		const days = Math.round(
+			(startOfDay(date).getTime() - anchor.getTime()) / MS_PER_DAY,
+		);
+		return days >= 0 && days % Math.max(1, habit.intervalDays) === 0;
 	}
 	return true;
 }
@@ -213,7 +244,14 @@ export function currentStreak(habit: HabitDefinition, today: Date): number {
 	let cursor = startOfDay(today);
 	let streak = 0;
 	let graceUsed = false;
+	// An interval habit is never due before its anchor, so without a floor
+	// the walk below would search backwards forever.
+	const floor =
+		habit.frequency === "interval" ? intervalAnchor(habit) : null;
 	for (;;) {
+		if (floor && cursor.getTime() < floor.getTime()) {
+			break;
+		}
 		if (!isDue(habit, cursor)) {
 			cursor = addDays(cursor, -1);
 			continue;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,10 +11,12 @@ export type HabitType = "binary" | "repetition" | "timed";
  * How often a habit is due.
  *
  * - `daily`: due every day (the original behaviour).
- * - `weekly`: due once a week, on a chosen weekday.
+ * - `weekly`: due on one or more chosen weekdays each week.
  * - `monthly`: due once a month, on a chosen day of the month.
+ * - `interval`: due every N days, counted from the habit's start date
+ *   (e.g. every 2 days for an alternate-day schedule).
  */
-export type HabitFrequency = "daily" | "weekly" | "monthly";
+export type HabitFrequency = "daily" | "weekly" | "monthly" | "interval";
 
 /**
  * Which way a habit's goal points.
@@ -90,17 +92,25 @@ export interface HabitDefinition {
 	/** How often the habit is due. Defaults to `daily`. */
 	frequency: HabitFrequency;
 	/**
-	 * Day of the week a weekly habit is due, as a JavaScript `getDay` value
-	 * (`0` = Sunday … `6` = Saturday). Only meaningful when `frequency` is
-	 * `weekly`.
+	 * Days of the week a weekly habit is due, as JavaScript `getDay` values
+	 * (`0` = Sunday … `6` = Saturday), sorted and without duplicates. Only
+	 * meaningful when `frequency` is `weekly`. Stored in frontmatter as a
+	 * scalar `weekday` when there is one day (the original format) or as a
+	 * `weekdays` list when there are several.
 	 */
-	weekday: number;
+	weekdays: number[];
 	/**
 	 * Day of the month a monthly habit is due (`1`–`31`). Only meaningful when
 	 * `frequency` is `monthly`. In months shorter than the chosen day it is
 	 * clamped to the last day of that month (so `31` acts as "last day").
 	 */
 	monthDay: number;
+	/**
+	 * Number of days between due dates (`2`–`365`), counted from the habit's
+	 * start date. Only meaningful when `frequency` is `interval`; `2` gives an
+	 * alternate-day schedule.
+	 */
+	intervalDays: number;
 	/**
 	 * Daily target. For `repetition` this is a count; for `timed` it is a
 	 * number of minutes. Ignored for `binary`.
@@ -161,8 +171,9 @@ export interface NewHabitOptions {
 	type: HabitType;
 	goalDirection: GoalDirection;
 	frequency: HabitFrequency;
-	weekday: number;
+	weekdays: number[];
 	monthDay: number;
+	intervalDays: number;
 	target: number;
 	unit: string;
 	weeklyTarget: number;

--- a/src/ui/dashboard.ts
+++ b/src/ui/dashboard.ts
@@ -876,21 +876,38 @@ export class HabitsDashboard extends MarkdownRenderChild {
 		});
 	}
 
-	/** A short "due" descriptor for weekly/monthly cards; empty for daily. */
+	/** A short "due" descriptor for non-daily cards; empty for daily. */
 	private frequencyLabel(habit: HabitDefinition): string {
 		if (habit.frequency === "weekly") {
-			const ref = new Date();
-			ref.setDate(
-				ref.getDate() + ((habit.weekday - ref.getDay() + 7) % 7),
-			);
-			return t("Every {day}", {
-				day: ref.toLocaleDateString(undefined, { weekday: "long" }),
-			});
+			if (habit.weekdays.length === 1) {
+				return t("Every {day}", {
+					day: this.weekdayName(habit.weekdays[0], "long"),
+				});
+			}
+			// Monday-first reads as a week plan ("Mon, Wed, Fri") whatever
+			// the underlying Sunday-based getDay values are.
+			const days = [...habit.weekdays]
+				.sort((a, b) => ((a + 6) % 7) - ((b + 6) % 7))
+				.map((day) => this.weekdayName(day, "short"))
+				.join(", ");
+			return t("Every {day}", { day: days });
 		}
 		if (habit.frequency === "monthly") {
 			return t("Monthly · day {day}", { day: habit.monthDay });
 		}
+		if (habit.frequency === "interval") {
+			return habit.intervalDays === 2
+				? t("Every other day")
+				: t("Every {n} days", { n: habit.intervalDays });
+		}
 		return "";
+	}
+
+	/** Locale-aware weekday name for a `getDay` value (2024-01-07 = Sunday). */
+	private weekdayName(value: number, style: "long" | "short"): string {
+		return new Date(2024, 0, 7 + value).toLocaleDateString(undefined, {
+			weekday: style,
+		});
 	}
 
 	private currentValue(habit: HabitDefinition): number {

--- a/src/ui/habit-metrics.ts
+++ b/src/ui/habit-metrics.ts
@@ -51,6 +51,7 @@ const RECENT_POINTS: Record<HabitFrequency, number> = {
 	daily: 30,
 	weekly: 16,
 	monthly: 12,
+	interval: 16,
 };
 
 /** Trailing window, in due periods, for the rolling completion-rate line. */
@@ -58,6 +59,7 @@ const ROLLING_WINDOW: Record<HabitFrequency, number> = {
 	daily: 7,
 	weekly: 4,
 	monthly: 3,
+	interval: 5,
 };
 
 /**
@@ -271,7 +273,7 @@ export class HabitMetrics extends MarkdownRenderChild {
 		const completedLabel =
 			habit.goalDirection === "max"
 				? t("Days within limit")
-				: habit.frequency === "weekly"
+				: habit.frequency === "weekly" && habit.weekdays.length === 1
 					? t("Weeks completed")
 					: habit.frequency === "monthly"
 						? t("Months completed")
@@ -543,7 +545,9 @@ export class HabitMetrics extends MarkdownRenderChild {
 		const title =
 			habit.frequency === "weekly"
 				? t("Weekly activity")
-				: t("Monthly activity");
+				: habit.frequency === "interval"
+					? t("Activity on due days")
+					: t("Monthly activity");
 		this.createChart(title, {
 			type: "bar",
 			data: { labels, datasets },
@@ -607,7 +611,9 @@ export class HabitMetrics extends MarkdownRenderChild {
 		const title =
 			habit.frequency === "weekly"
 				? t("{n}-week completion rate", { n: window })
-				: t("{n}-month completion rate", { n: window });
+				: habit.frequency === "interval"
+					? t("Completion rate over {n} due days", { n: window })
+					: t("{n}-month completion rate", { n: window });
 		this.createChart(title, {
 			type: "line",
 			data: {

--- a/src/ui/habit-modal.ts
+++ b/src/ui/habit-modal.ts
@@ -55,6 +55,16 @@ const WEEKDAYS: readonly { label: string; value: number }[] = [
 	{ label: "Sunday", value: 0 },
 ];
 
+/**
+ * Locale-aware short weekday name (e.g. "Mon", "lun.", "月") for a `getDay`
+ * value. 2024-01-07 was a Sunday, so day 7 + value lands on the right day.
+ */
+function weekdayShortLabel(value: number): string {
+	return new Date(2024, 0, 7 + value).toLocaleDateString(undefined, {
+		weekday: "short",
+	});
+}
+
 /** Suggests existing group names while typing in the group field. */
 class GroupSuggest extends AbstractInputSuggest<string> {
 	constructor(
@@ -179,8 +189,9 @@ export class HabitModal extends Modal {
 	private type: HabitType = "binary";
 	private goalDirection: GoalDirection = "min";
 	private frequency: HabitFrequency = "daily";
-	private weekday = new Date().getDay();
+	private weekdays: number[] = [new Date().getDay()];
 	private monthDay = new Date().getDate();
+	private intervalDays = 2;
 	private target = 1;
 	private unit = "";
 	private weeklyTarget = 0;
@@ -224,9 +235,11 @@ export class HabitModal extends Modal {
 			this.goalDirection = editing.goalDirection;
 			this.frequency = editing.frequency;
 			if (editing.frequency === "weekly") {
-				this.weekday = editing.weekday;
+				this.weekdays = [...editing.weekdays];
 			} else if (editing.frequency === "monthly") {
 				this.monthDay = editing.monthDay;
+			} else if (editing.frequency === "interval") {
+				this.intervalDays = editing.intervalDays;
 			}
 			// A limit habit's target may legitimately be 0 ("none at all");
 			// only build habits coerce a missing target to 1.
@@ -479,8 +492,9 @@ export class HabitModal extends Modal {
 								this.goalDirection === "max"
 									? ("daily" as HabitFrequency)
 									: this.frequency,
-							weekday: this.weekday,
+							weekdays: [...this.weekdays],
 							monthDay: this.monthDay,
+							intervalDays: this.intervalDays,
 							target: this.target,
 							unit: this.unit,
 							weeklyTarget: this.weeklyTarget,
@@ -691,8 +705,9 @@ export class HabitModal extends Modal {
 	}
 
 	/**
-	 * Frequency picker: daily, weekly (with a weekday) or monthly (with a day
-	 * of the month). Weekly and monthly habits only surface on their due date.
+	 * Frequency picker: daily, weekly (with one or more weekdays), monthly
+	 * (with a day of the month) or every N days. Non-daily habits only
+	 * surface on their due dates.
 	 */
 	private renderFrequency(contentEl: HTMLElement): void {
 		new Setting(contentEl)
@@ -707,6 +722,7 @@ export class HabitModal extends Modal {
 					.addOption("daily", t("Daily"))
 					.addOption("weekly", t("Weekly"))
 					.addOption("monthly", t("Monthly"))
+					.addOption("interval", t("Every N days"))
 					.setValue(this.frequency)
 					.onChange((value) => {
 						this.frequency = value as HabitFrequency;
@@ -715,18 +731,71 @@ export class HabitModal extends Modal {
 			);
 
 		if (this.frequency === "weekly") {
-			new Setting(contentEl)
-				.setName(t("Day of week"))
-				.setDesc(t("The weekday this habit is due on."))
-				.addDropdown((dropdown) => {
-					for (const day of WEEKDAYS) {
-						dropdown.addOption(String(day.value), t(day.label));
+			const setting = new Setting(contentEl)
+				.setName(t("Days of week"))
+				.setDesc(
+					t(
+						"The weekdays this habit is due on. Pick as many as you need.",
+					),
+				);
+			const row = setting.controlEl.createDiv({
+				cls: "habits-weekday-picker",
+			});
+			for (const day of WEEKDAYS) {
+				const active = (): boolean =>
+					this.weekdays.includes(day.value);
+				const pill = row.createEl("button", {
+					cls: "habits-weekday-pill",
+					text: weekdayShortLabel(day.value),
+					attr: {
+						type: "button",
+						"aria-label": t(day.label),
+						"aria-pressed": String(active()),
+					},
+				});
+				pill.toggleClass("is-active", active());
+				pill.addEventListener("click", () => {
+					if (active()) {
+						// Keep at least one day selected: a weekly habit
+						// due on no day at all would simply never appear.
+						if (this.weekdays.length === 1) {
+							return;
+						}
+						this.weekdays = this.weekdays.filter(
+							(value) => value !== day.value,
+						);
+					} else {
+						this.weekdays = [...this.weekdays, day.value].sort(
+							(a, b) => a - b,
+						);
 					}
-					dropdown
-						.setValue(String(this.weekday))
-						.onChange((value) => {
-							this.weekday = Number(value);
-						});
+					pill.toggleClass("is-active", active());
+					pill.setAttr("aria-pressed", String(active()));
+				});
+			}
+		}
+
+		if (this.frequency === "interval") {
+			new Setting(contentEl)
+				.setName(t("Repeat every"))
+				.setDesc(
+					t(
+						"Number of days between due dates, counted from the habit's start date. Use 2 for an alternate-day schedule.",
+					),
+				)
+				.addText((text) => {
+					applyNumeric(text.inputEl, 2, 365);
+					text.setValue(String(this.intervalDays)).onChange(
+						(value) => {
+							const parsed = Math.round(Number(value));
+							if (Number.isFinite(parsed)) {
+								this.intervalDays = Math.min(
+									365,
+									Math.max(2, parsed),
+								);
+							}
+						},
+					);
 				});
 		}
 

--- a/styles.css
+++ b/styles.css
@@ -2301,3 +2301,35 @@
 	color: var(--text-muted);
 	font-size: var(--font-ui-small);
 }
+
+/* Weekday pills (multi-day picker in the habit modal) */
+
+.habits-weekday-picker {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.35rem;
+}
+
+.habits-weekday-picker button.habits-weekday-pill {
+	min-width: 2.6em;
+	padding: 0.25em 0.55em;
+	border-radius: var(--radius-l);
+	border: 1px solid var(--background-modifier-border);
+	background-color: var(--background-secondary);
+	background-image: none;
+	color: var(--text-muted);
+	font-size: var(--font-ui-small);
+	cursor: pointer;
+	box-shadow: none;
+}
+
+.habits-weekday-picker button.habits-weekday-pill:hover {
+	border-color: var(--background-modifier-border-hover);
+	color: var(--text-normal);
+}
+
+.habits-weekday-picker button.habits-weekday-pill.is-active {
+	background-color: var(--interactive-accent);
+	border-color: var(--interactive-accent);
+	color: var(--text-on-accent);
+}


### PR DESCRIPTION
Closes #5

Two new scheduling forms, both designed so every existing habit note parses and round-trips unchanged.

## What's added

**Weekly habits on several weekdays** — the modal's weekday dropdown becomes a row of locale-aware toggle pills (at least one always stays selected). A Mon/Wed/Fri gym habit is now one note, one card, one streak.

**Every N days** — a new `Every N days` frequency (`interval`) with a days input (2–365). Due dates are counted from the habit's `startDate`, so an alternate-day schedule stays put when a day is missed — like a prescription. Hand-written notes without a `startDate` anchor on their earliest record; with neither, the habit behaves as daily until one exists.

## Frontmatter compatibility

| Schedule | Stored as |
| --- | --- |
| Weekly, one day | `weekday: 5` — **unchanged**, existing notes round-trip byte-identical |
| Weekly, several days | `weekdays: [1, 3, 5]` |
| Every N days | `frequency: interval` + `intervalDays: 2` |

The parser accepts both `weekday` and `weekdays` (clamped 0–6, deduplicated, sorted; falls back to Monday like the old scalar default), and `writeFrequency` still deletes whichever keys the chosen frequency doesn't use, so stale keys never linger.

## Design notes

- `isDue()` in `stats.ts` stays the single due-ness predicate, so the dashboard, sidebar panel, streaks, heatmap, stats view, charts and AI summaries all pick the new forms up with no per-view logic.
- **Termination fix that interval scheduling exposes:** `currentStreak()` walks backwards with `for (;;)`, relying on every frequency being due *eventually*. An interval habit is never due before its anchor, so the walk gains a floor at the anchor date and breaks there.
- Interval due-day math uses local midnights with `Math.round`, so the odd hour a DST transition adds or removes inside a span doesn't shift due days.
- Streaks and stats count due days, not calendar days — unchanged in spirit: a Mon/Wed/Fri streak is consecutive due days; skipped days in between neither break nor extend it.
- Metrics adapt: multi-weekday and interval habits use the due-date activity/rate charts, with the "Weeks completed" tile relabelled to "Days completed" where a week now holds several due days.
- New UI strings are translated in all six bundled locales (es, fr, de, zh, ja, ko); anything missed falls back to English via the existing natural-key mechanism.
- README's frequency section and feature list are updated.

## Testing

- `npm run build` (tsc + esbuild) and `npm run lint` are clean.
- The scheduling logic (`isDue`, `intervalAnchor`, `currentStreak`) was exercised by a 27-assertion harness — multi-weekday due-ness and streaks including the today-grace rule, single-day legacy behaviour, every-2/every-3 phase math, anchor fallback to earliest record, no-anchor fallback, dates before the anchor, streak-walk termination time, and a US DST-transition date — run under two timezones (`America/New_York`, `Asia/Kolkata`), all passing.
- Manually exercised in my own vault: dashboard in daily notes, sidebar panel, card labels ("Every Mon, Wed, Fri", "Every other day"), and the modal round-trip (create → edit → save keeps the chosen days).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
