### PR TITLE
Panel: show planned times next to habit names

### DIFF
--- a/src/ui/panel-view.ts
+++ b/src/ui/panel-view.ts
@@ -13,6 +13,7 @@ import type { HabitsPluginSettings } from "../settings";
 import type { HabitDefinition } from "../types";
 import { isComplete, isDue, isPausedOn, limitOf } from "../stats";
 import {
+	formatTimeOfDay,
 	groupHabits,
 	habitAccent,
 	registerLongPress,
@@ -357,6 +358,15 @@ export class HabitsPanelView extends ItemView {
 		this.registerDomEvent(name, "click", () => {
 			void this.app.workspace.openLinkText(habit.path, "", false);
 		});
+
+		if (habit.times.length > 0) {
+			// All times stay visible; the name truncates instead and its
+			// tooltip already reveals the full name.
+			main.createSpan({
+				cls: "habits-panel-time",
+				text: habit.times.map(formatTimeOfDay).join(", "),
+			});
+		}
 
 		if (this.isPausedToday(habit)) {
 			row.addClass("is-paused");

--- a/styles.css
+++ b/styles.css
@@ -1963,6 +1963,14 @@
 	text-decoration: underline;
 }
 
+.habits-panel-time {
+	flex: 0 0 auto;
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+	font-variant-numeric: tabular-nums;
+	white-space: nowrap;
+}
+
 .habits-panel .habits-panel-value {
 	flex: 0 0 auto;
 	margin: 0;


### PR DESCRIPTION
## Summary
- The sidebar panel never rendered a habit's planned times, while the dashboard cards already show them in their schedule line.
- Each panel row now shows the habit's planned times in a small muted label after the name (e.g. `Gym for 1.5hrs  7:00 AM`), reusing the shared locale-aware `formatTimeOfDay` so it follows the system 12/24-hour setting. Several times render comma-separated; habits with no planned time are unchanged.
- The time label never shrinks — the habit name truncates first when the row gets tight, and its existing tooltip reveals the full name.

## Testing
- `npm run build` passes (tsc + esbuild).
- Verified in a vault: times show for binary, counter (with −/+ controls), and timed rows at narrow sidebar widths; rows without times are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)